### PR TITLE
Fixed broken link generation

### DIFF
--- a/confluence.lua
+++ b/confluence.lua
@@ -148,7 +148,7 @@ function Link(s, src, tit, attr)
     -- [Anchor Link](#anchor), taken from https://confluence.atlassian.com/doc/confluence-storage-format-790796544.html#ConfluenceStorageFormat-Links
     return LinkToAnchor(escape(string.sub(src, 2, -1), true), s)
   else
-    return string.sub(src, 0, 1) .. src .. "<a href='" .. escape(src,true) .. "' title='" ..
+    return "<a href='" .. escape(src,true) .. "' title='" ..
            escape(tit,true) .. "'>" .. s .. "</a>"
   end
 end


### PR DESCRIPTION
A link in markdown for example `[Link](http://awesome.link)` generated
as `hhttp://awesome.link<a href='http://awesome.link' title=''>Link</a>`

Instead of expected
`<a href='http://awesome.link' title=''>Link</a>`