### PR TITLE
Changed that a code block is using confluence's code block macro

### DIFF
--- a/confluence.lua
+++ b/confluence.lua
@@ -254,8 +254,13 @@ function CodeBlock(s, attr)
     return '<img src="data:image/png;base64,' .. png .. '"/>'
   -- otherwise treat as code (one could pipe through a highlighter)
   else
-    return "<pre><code" .. attributes(attr) .. ">" .. escape(s) ..
-           "</code></pre>"
+    return '<ac:structured-macro ac:macro-id="761760bb-a501-4b9f-9b5e-f7ebf7e1ab21" ' ..
+                    'ac:name="code" ac:schema-version="1">' ..
+                '<ac:parameter ac:name="language">' .. attr.class ..
+       '</ac:parameter>' ..
+                '<ac:plain-text-body><![CDATA[' ..
+       s ..']]></ac:plain-text-body>' ..
+            '</ac:structured-macro>'
   end
 end
 


### PR DESCRIPTION
Instead of the <pre><code ...></code></pre>