### PR TITLE
Added support for links between confluence pages

### DIFF
--- a/confluence.lua
+++ b/confluence.lua
@@ -144,7 +144,14 @@ function Strikeout(s)
 end
 
 function Link(s, src, tit, attr)
-  if src and string.sub(src, 1, 1) == "#" then
+  if src and string.sub(src, 1, 11) == "confluence:" then
+     -- [Page Link](confluence:SPACE:Content Title)
+     for space, page in src:gsub('%%20',' '):gmatch('confluence:(%w+):([%w%s]+)')
+     do
+        return string.format('<ac:link><ri:page ri:space-key="%s" '..
+                             'ri:content-title="%s" /></ac:link>', space, page)
+     end
+  elseif src and string.sub(src, 1, 1) == "#" then
     -- [Anchor Link](#anchor), taken from https://confluence.atlassian.com/doc/confluence-storage-format-790796544.html#ConfluenceStorageFormat-Links
     return LinkToAnchor(escape(string.sub(src, 2, -1), true), s)
   else


### PR DESCRIPTION
Using a custom syntax in markdown:
[Link](confluence:SPACE:Content Title)